### PR TITLE
Fix invalid class name

### DIFF
--- a/theme.less
+++ b/theme.less
@@ -58,7 +58,7 @@
 .cm-def, .cm-variable-2 {
   color: @cyan;
 }
-.cm-variable, cm-variable-3, .cm-meta {
+.cm-variable, .cm-variable-3, .cm-meta {
   color: @pale;
 }
 .cm-property, .cm-attribute {


### PR DESCRIPTION
Dot was missed in class name. That's why some elements didn't paint as need. For example: ":after",":before" etc.
